### PR TITLE
Use uint64 in countQuery, TxCount, Count()

### DIFF
--- a/find_test.go
+++ b/find_test.go
@@ -1168,7 +1168,7 @@ func TestCount(t *testing.T) {
 					t.Fatalf("Error counting data from badgerhold: %s", err)
 				}
 
-				if count != len(tst.result) {
+				if count != uint64(len(tst.result)) {
 					t.Fatalf("Count result is %d wanted %d.", count, len(tst.result))
 				}
 			})

--- a/get.go
+++ b/get.go
@@ -91,8 +91,8 @@ func (s *Store) TxFindOne(tx *badger.Txn, result interface{}, query *Query) erro
 }
 
 // Count returns the current record count for the passed in datatype
-func (s *Store) Count(dataType interface{}, query *Query) (int, error) {
-	count := 0
+func (s *Store) Count(dataType interface{}, query *Query) (uint64, error) {
+	var count uint64 = 0
 	err := s.Badger().View(func(tx *badger.Txn) error {
 		var txErr error
 		count, txErr = s.TxCount(tx, dataType, query)
@@ -102,7 +102,7 @@ func (s *Store) Count(dataType interface{}, query *Query) (int, error) {
 }
 
 // TxCount returns the current record count from within the given transaction for the passed in datatype
-func (s *Store) TxCount(tx *badger.Txn, dataType interface{}, query *Query) (int, error) {
+func (s *Store) TxCount(tx *badger.Txn, dataType interface{}, query *Query) (uint64, error) {
 	return countQuery(tx, dataType, query)
 }
 

--- a/query.go
+++ b/query.go
@@ -1106,12 +1106,12 @@ func forEach(tx *badger.Txn, query *Query, fn interface{}) error {
 	})
 }
 
-func countQuery(tx *badger.Txn, dataType interface{}, query *Query) (int, error) {
+func countQuery(tx *badger.Txn, dataType interface{}, query *Query) (uint64, error) {
 	if query == nil {
 		query = &Query{}
 	}
 
-	count := 0
+	var count uint64 = 0
 
 	err := runQuery(tx, dataType, query, nil, query.skip,
 		func(r *record) error {


### PR DESCRIPTION
Right now, `countQuery` (and thereby the exposed `Count()` and `TxCount()`) uses an `int` to count records, meaning only ~2 billion records are supported before the count could overflow.  

This pr uses `uint` instead, increasing that value to ~10^19. 