### PR TITLE
Handle errors

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -35,7 +35,7 @@ func (s *Store) TxDelete(tx *badger.Txn, key, dataType interface{}) error {
 		return err
 	}
 
-	item.Value(func(bVal []byte) error {
+	err = item.Value(func(bVal []byte) error {
 		return s.decode(bVal, value)
 	})
 	if err != nil {

--- a/get.go
+++ b/get.go
@@ -36,6 +36,9 @@ func (s *Store) TxGet(tx *badger.Txn, key, result interface{}) error {
 	if err == badger.ErrKeyNotFound {
 		return ErrNotFound
 	}
+	if err != nil {
+		return err
+	}
 
 	err = item.Value(func(value []byte) error {
 		return s.decode(value, result)

--- a/store_test.go
+++ b/store_test.go
@@ -7,13 +7,12 @@ package badgerhold_test
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
-	"reflect"
-	"runtime"
-
 	// "fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/timshannon/badgerhold/v3"
@@ -107,7 +106,10 @@ func TestGetUnknownType(t *testing.T) {
 // utilities
 
 func testWrap(t *testing.T, tests func(store *badgerhold.Store, t *testing.T)) {
-	opt := testOptions()
+	testWrapWithOpt(t, testOptions(), tests)
+}
+
+func testWrapWithOpt(t *testing.T, opt badgerhold.Options, tests func(store *badgerhold.Store, t *testing.T)) {
 	var err error
 	store, err := badgerhold.Open(opt)
 	if err != nil {


### PR DESCRIPTION
In some places errors aren't handled correctly. That leads to unexpected behaviour sometimes. 
For example: in case `IndexFunc` returns an error `badgerhold.Add` will succeed without adding value to the index.