### PR TITLE
Optimise index queries with `eq` and `in` operators

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -30,7 +30,7 @@ var benchItem = BenchData{
 	Category: "test category",
 }
 
-var benchItemIndexed = BenchData{
+var benchItemIndexed = BenchDataIndexed{
 	ID:       30,
 	Category: "test category",
 }
@@ -218,7 +218,7 @@ func BenchmarkFindIndexed(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var result []BenchDataIndexed
 
-			err := store.Find(&result, badgerhold.Where("Category").Eq("findCategory"))
+			err := store.Find(&result, badgerhold.Where("Category").Eq("findCategory").Index("Category"))
 			if err != nil {
 				b.Fatalf("Error finding data in store: %s", err)
 			}

--- a/bench_test.go
+++ b/bench_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/dgraph-io/badger/v3"
@@ -218,7 +219,50 @@ func BenchmarkFindIndexed(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var result []BenchDataIndexed
 
-			err := store.Find(&result, badgerhold.Where("Category").Eq("findCategory").Index("Category"))
+			err := store.Find(
+				&result,
+				badgerhold.Where("Category").Eq("findCategory").Index("Category"),
+			)
+			if err != nil {
+				b.Fatalf("Error finding data in store: %s", err)
+			}
+		}
+	})
+}
+
+func BenchmarkFindIndexedWithManyIndexValues(b *testing.B) {
+	benchWrap(b, nil, func(store *badgerhold.Store, b *testing.B) {
+		for i := 0; i < 3; i++ {
+			for k := 0; k < 100; k++ {
+				itemID := int(idVal) + 1
+				item := BenchDataIndexed{
+					ID:       itemID,
+					Category: strconv.Itoa(itemID),
+				}
+				err := store.Insert(id(), item)
+				if err != nil {
+					b.Fatalf("Error inserting benchmarking data: %s", err)
+				}
+			}
+			err := store.Insert(id(), &BenchDataIndexed{
+				ID:       30,
+				Category: "findCategory",
+			})
+			if err != nil {
+				b.Fatalf("Error inserting benchmarking data: %s", err)
+			}
+
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var result []BenchDataIndexed
+
+			err := store.Find(
+				&result,
+				badgerhold.Where("Category").Eq("findCategory").Index("Category"),
+			)
 			if err != nil {
 				b.Fatalf("Error finding data in store: %s", err)
 			}

--- a/index.go
+++ b/index.go
@@ -107,6 +107,11 @@ func indexKeyPrefix(typeName, indexName string) []byte {
 	return []byte(indexPrefix + ":" + typeName + ":" + indexName + ":")
 }
 
+// newIndexKey returns the badger key where this index is stored
+func newIndexKey(typeName, indexName string, value []byte) []byte {
+	return append(indexKeyPrefix(typeName, indexName), value...)
+}
+
 // KeyList is a slice of unique, sorted keys([]byte) such as what an index points to
 type KeyList [][]byte
 

--- a/query.go
+++ b/query.go
@@ -707,7 +707,10 @@ func (s *Store) runQuery(tx *badger.Txn, dataType interface{}, query *Query, ret
 	}
 
 	query.dataType = reflect.TypeOf(tp)
-	query.validateIndex()
+	err := query.validateIndex()
+	if err != nil {
+		return err
+	}
 
 	if len(query.sort) > 0 {
 		return s.runQuerySort(tx, dataType, query, action)

--- a/store.go
+++ b/store.go
@@ -207,7 +207,6 @@ func typePrefix(typeName string) []byte {
 }
 
 func getKeyField(tp reflect.Type) (reflect.StructField, bool) {
-
 	for i := 0; i < tp.NumField(); i++ {
 		if strings.HasPrefix(string(tp.Field(i).Tag), BadgerholdKeyTag) {
 			return tp.Field(i), true


### PR DESCRIPTION
Partially resolves https://github.com/timshannon/badgerhold/issues/77 for queries with `eq` and `in` operators.
It queries badger database directly instead of using iterator.