### PR TITLE
Support sorting in find query with index

### DIFF
--- a/find_test.go
+++ b/find_test.go
@@ -1243,3 +1243,22 @@ func TestIssue74HasPrefixOnKeys(t *testing.T) {
 		ok(t, store.FindOne(result, badgerhold.Where(badgerhold.Key).HasSuffix("test")))
 	})
 }
+
+func TestFindIndexedWithSort(t *testing.T) {
+	testWrap(t, func(store *badgerhold.Store, t *testing.T) {
+		insertTestData(t, store)
+		results := make([]ItemTest, 1)
+		ok(t, store.Find(
+			&results,
+			badgerhold.Where("Category").Eq("vehicle").Index("Category").
+				SortBy("Name").Skip(1).Limit(3),
+		))
+
+		expectedIDs := []int{11, 1, 3}
+		equals(t, len(expectedIDs), len(results))
+
+		for i := range results {
+			assert(t, testData[expectedIDs[i]].equal(&results[i]), "incorrect rows returned")
+		}
+	})
+}

--- a/find_test.go
+++ b/find_test.go
@@ -1262,3 +1262,18 @@ func TestFindIndexedWithSort(t *testing.T) {
 		}
 	})
 }
+
+func TestFindWithStorerImplementation(t *testing.T) {
+	testWrap(t, func(store *badgerhold.Store, t *testing.T) {
+		customStorerItem := &ItemWithStorer{Name: "pizza"}
+		ok(t, store.Insert(1, customStorerItem))
+
+		results := make([]ItemWithStorer, 1)
+		ok(t, store.Find(
+			&results,
+			badgerhold.Where("Name").Eq("pizza").Index("Name"),
+		))
+
+		equals(t, *customStorerItem, results[0])
+	})
+}

--- a/store_test.go
+++ b/store_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	// "fmt"
 	"io/ioutil"
 	"os"
@@ -111,13 +110,13 @@ type Issue115 struct{ Name string }
 func (i *Issue115) Type() string { return "Item" }
 func (i *Issue115) Indexes() map[string]badgerhold.Index {
 	return map[string]badgerhold.Index{
-		"Name": badgerhold.Index{
+		"Name": {
 			IndexFunc: func(_ string, value interface{}) ([]byte, error) {
 				// If the upsert wants to delete an existing value first,
 				// value could be a **Item instead of *Item
 				// panic: interface conversion: interface {} is **Item, not *Item
 				v := value.(*Issue115).Name
-				return []byte(v), nil
+				return badgerhold.DefaultEncode(v)
 			},
 			Unique: false,
 		},

--- a/store_test.go
+++ b/store_test.go
@@ -105,17 +105,17 @@ func TestGetUnknownType(t *testing.T) {
 	}
 }
 
-type Issue115 struct{ Name string }
+type ItemWithStorer struct{ Name string }
 
-func (i *Issue115) Type() string { return "Item" }
-func (i *Issue115) Indexes() map[string]badgerhold.Index {
+func (i *ItemWithStorer) Type() string { return "Item" }
+func (i *ItemWithStorer) Indexes() map[string]badgerhold.Index {
 	return map[string]badgerhold.Index{
 		"Name": {
 			IndexFunc: func(_ string, value interface{}) ([]byte, error) {
 				// If the upsert wants to delete an existing value first,
 				// value could be a **Item instead of *Item
 				// panic: interface conversion: interface {} is **Item, not *Item
-				v := value.(*Issue115).Name
+				v := value.(*ItemWithStorer).Name
 				return badgerhold.DefaultEncode(v)
 			},
 			Unique: false,
@@ -125,7 +125,7 @@ func (i *Issue115) Indexes() map[string]badgerhold.Index {
 
 func TestIssue115(t *testing.T) {
 	testWrap(t, func(store *badgerhold.Store, t *testing.T) {
-		item := &Issue115{"Name"}
+		item := &ItemWithStorer{"Name"}
 		for i := 0; i < 2; i++ {
 			err := store.Upsert("key", item)
 			if err != nil {


### PR DESCRIPTION
That PR contains few improvements:
- supports custom storer implementation in `validateIndex` function
- supports sorting and limiting in findByIndexQuery