### PR TITLE
Support index queries with `And` criterion 

### DIFF
--- a/find_test.go
+++ b/find_test.go
@@ -1247,7 +1247,7 @@ func TestIssue74HasPrefixOnKeys(t *testing.T) {
 func TestFindIndexedWithSort(t *testing.T) {
 	testWrap(t, func(store *badgerhold.Store, t *testing.T) {
 		insertTestData(t, store)
-		results := make([]ItemTest, 1)
+		results := make([]ItemTest, 0, 3)
 		ok(t, store.Find(
 			&results,
 			badgerhold.Where("Category").Eq("vehicle").Index("Category").

--- a/find_test.go
+++ b/find_test.go
@@ -1263,6 +1263,24 @@ func TestFindIndexedWithSort(t *testing.T) {
 	})
 }
 
+func TestFindIndexedWithResultSliceOfPointers(t *testing.T) {
+	testWrap(t, func(store *badgerhold.Store, t *testing.T) {
+		insertTestData(t, store)
+		results := make([]*ItemTest, 0, 3)
+		ok(t, store.Find(
+			&results,
+			badgerhold.Where("Category").Eq("vehicle").Index("Category"),
+		))
+
+		expectedIDs := []int{0, 1, 3, 6, 11}
+		equals(t, len(expectedIDs), len(results))
+
+		for i := range results {
+			assert(t, testData[expectedIDs[i]].equal(results[i]), "incorrect rows returned")
+		}
+	})
+}
+
 func TestFindWithStorerImplementation(t *testing.T) {
 	testWrap(t, func(store *badgerhold.Store, t *testing.T) {
 		customStorerItem := &ItemWithStorer{Name: "pizza"}

--- a/query.go
+++ b/query.go
@@ -1331,7 +1331,7 @@ func (s *Store) findByIndexQuery(tx *badger.Txn, resultSlice reflect.Value, quer
 	for i := range keyList {
 		item, err := tx.Get(keyList[i])
 		if err == badger.ErrKeyNotFound {
-			continue
+			panic("inconsistency between keys stored in index and in Badger directly")
 		}
 		if err != nil {
 			return err

--- a/query.go
+++ b/query.go
@@ -1004,7 +1004,7 @@ func (s *Store) findQuery(tx *badger.Txn, result interface{}, query *Query) erro
 }
 
 func isFindByIndexQuery(query *Query) bool {
-	if query.index == "" || len(query.fieldCriteria) != 1 || len(query.fieldCriteria[query.index]) != 1 || len(query.ors) > 0 {
+	if query.index == "" || len(query.fieldCriteria) == 0 || len(query.fieldCriteria[query.index]) != 1 || len(query.ors) > 0 {
 		return false
 	}
 
@@ -1349,6 +1349,14 @@ func (s *Store) findByIndexQuery(tx *badger.Txn, resultSlice reflect.Value, quer
 			if err != nil {
 				return err
 			}
+		}
+
+		ok, err := query.matchesAllFields(s, keyList[i], newElement, newElement.Interface())
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
 		}
 
 		if query.dataType.Kind() != reflect.Ptr {

--- a/query.go
+++ b/query.go
@@ -1359,7 +1359,7 @@ func (s *Store) findByIndexQuery(tx *badger.Txn, resultSlice reflect.Value, quer
 			continue
 		}
 
-		if query.dataType.Kind() != reflect.Ptr {
+		if sliceType.Elem().Kind() != reflect.Ptr {
 			newElement = newElement.Elem()
 		}
 		slice = reflect.Append(slice, newElement)

--- a/store_test.go
+++ b/store_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	// "fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Queries with `Index` and additional criteria will benefit from querying BH index directly and check if given value match criteria on smaller dataset. 
There are existing tests that cover that case.